### PR TITLE
Added setUp instructions in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ To load your package alias, override the `getPackageAliases`.
 
 Since `Orchestral\TestCase` overrides Laravel's `TestCase`, if you need your own `setUp()` implementation, do not forget to call `parent::setUp()`:
 
+```php
     public function setUp()
     {
     	parent::setUp();
 
     	// Your code here
     }
+```
 
 ## Testing Route Filters
 


### PR DESCRIPTION
While using the package, it took me a few minutes to notice that I needed to call `parent::setUp()`, since before the package I was using plain `PHPUnit_Framework_TestCase` and it wasn't needed.

I've added specific instructions in README for this.
