### PR TITLE
Updated config for the PasswordResetServiceProvider

### DIFF
--- a/src/Testbench/Traits/ApplicationTrait.php
+++ b/src/Testbench/Traits/ApplicationTrait.php
@@ -97,7 +97,7 @@ trait ApplicationTrait
             'Illuminate\Pagination\PaginationServiceProvider',
             'Illuminate\Queue\QueueServiceProvider',
             'Illuminate\Redis\RedisServiceProvider',
-            'Illuminate\Auth\Reminders\ReminderServiceProvider',
+            'Illuminate\Auth\Passwords\PasswordResetServiceProvider',
             'Illuminate\Database\SeedServiceProvider',
             'Illuminate\Session\SessionServiceProvider',
             'Illuminate\Translation\TranslationServiceProvider',


### PR DESCRIPTION
This fix is important and fixes fatal errors breaking test suites such as: `PHP Fatal error:  Class 'Illuminate\Auth\Reminders\ReminderServiceProvider' not found in /home/travis/build/GrahamCampbell/Laravel-TestBench/vendor/laravel/framework/src/Illuminate/Foundation/ProviderRepository.php on line 157`.
