### PR TITLE
Moved the environment setup

### DIFF
--- a/src/Testbench/Traits/ApplicationTrait.php
+++ b/src/Testbench/Traits/ApplicationTrait.php
@@ -179,15 +179,15 @@ trait ApplicationTrait
         $providers = array_merge($this->getApplicationProviders(), $this->getPackageProviders());
         $app['config']['app.providers'] = $providers;
 
+        $this->resolveApplicationHttpKernel($app);
+        $this->resolveApplicationConsoleKernel($app);
+
         $app->make('Illuminate\Foundation\Bootstrap\SetRequestForConsole')->bootstrap($app);
         $app->make('Illuminate\Foundation\Bootstrap\RegisterProviders')->bootstrap($app);
 
         $this->getEnvironmentSetUp($app);
 
         $app->make('Illuminate\Foundation\Bootstrap\BootProviders')->bootstrap($app);
-
-        $this->resolveApplicationHttpKernel($app);
-        $this->resolveApplicationConsoleKernel($app);
 
         return $app;
     }


### PR DESCRIPTION
I propose call `getEnvironmentSetUp` earlier so that people can make config modifications before all the service providers have booted.

~~If you want, I could put it here instead?~~ **DONE**

``` php
$app->make('Illuminate\Foundation\Bootstrap\RegisterProviders')->bootstrap($app);
$this->getEnvironmentSetUp($app);
$app->make('Illuminate\Foundation\Bootstrap\BootProviders')->bootstrap($app);
```
