### PR TITLE
[3.0] Removed Dependency On "orchestra/database"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
 	},
 	"require": {
 		"php": ">=5.4.0",
-		"laravel/framework": "5.0.*",
-		"orchestra/database": "3.0.*"
+		"laravel/framework": "5.0.*"
 	},
 	"require-dev": {
 		"mockery/mockery": "0.9.*",

--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -124,8 +124,6 @@ trait ApplicationTrait
             'Illuminate\Translation\TranslationServiceProvider',
             'Illuminate\Validation\ValidationServiceProvider',
             'Illuminate\View\ViewServiceProvider',
-
-            'Orchestra\Database\MigrationServiceProvider',
         ];
     }
 


### PR DESCRIPTION
The `--path` argument has returned to `laravel/framework` so we don't need to pull in an extra package anymore. See https://github.com/laravel/framework/pull/7242.