### PR TITLE
Update Exceptionhandler to match laravel/framework 5.2 Exception Handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "laravel/framework": "~5.2.0",
+        "laravel/framework": "~5.2.7",
         "orchestra/database": "~3.2.0",
         "fzaninotto/faker": "~1.4",
         "symfony/css-selector": "2.8.*|3.0.*",

--- a/src/ApplictionTestCase.php
+++ b/src/ApplictionTestCase.php
@@ -1,0 +1,18 @@
+<?php namespace Orchestra\Testbench;
+
+use Orchestra\Testbench\Contracts\TestCase as TestCaseContract;
+
+class ApplicationTestCase extends TestCase implements TestCaseContract
+{
+    /**
+     * Resolve application HTTP exception handler.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return void
+     */
+    protected function resolveApplicationExceptionHandler($app)
+    {
+        $app->singleton('Illuminate\Contracts\Debug\ExceptionHandler', 'Orchestra\Testbench\Exceptions\ApplicationHandler');
+    }
+}

--- a/src/Exceptions/ApplicationHandler.php
+++ b/src/Exceptions/ApplicationHandler.php
@@ -1,0 +1,50 @@
+<?php namespace Orchestra\Testbench\Exceptions;
+
+use Exception;
+use Illuminate\Foundation\Testing\HttpException;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+
+class ApplicationHandler extends ExceptionHandler
+{
+    /**
+     * A list of the exception types that should not be reported.
+     *
+     * @var array
+     */
+    protected $dontReport = [
+        AuthorizationException::class,
+        HttpException::class,
+        ModelNotFoundException::class,
+        ValidationException::class,
+    ];
+
+    /**
+     * Report or log an exception.
+     *
+     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
+     *
+     * @param  \Exception  $e
+     * @return void
+     */
+    public function report(Exception $e)
+    {
+        parent::report($e);
+    }
+
+    /**
+     * Render an exception into an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Exception  $e
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request, Exception $e)
+    {
+        return parent::render($request, $e);
+    }
+}
+

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -1,50 +1,22 @@
 <?php namespace Orchestra\Testbench\Exceptions;
 
 use Exception;
-use Illuminate\Foundation\Testing\HttpException;
-use Illuminate\Auth\Access\AuthorizationException;
-use Illuminate\Contracts\Validation\ValidationException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
 {
     /**
-     * A list of the exception types that should not be reported.
-     *
-     * @var array
-     */
-    protected $dontReport = [
-        AuthorizationException::class,
-        HttpException::class,
-        ModelNotFoundException::class,
-        ValidationException::class,
-    ];
-
-    /**
-     * Report or log an exception.
-     *
-     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
-     *
-     * @param  \Exception  $e
-     * @return void
-     */
-    public function report(Exception $e)
-    {
-        return parent::report($e);
-    }
-
-    /**
      * Render an exception into an HTTP response.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $e
+     *
      * @return \Illuminate\Http\Response
+     *
+     * @throws \Exception
      */
     public function render($request, Exception $e)
     {
-        return parent::render($request, $e);
+        throw $e;
     }
 }
-

--- a/src/Exceptions/Handler.php
+++ b/src/Exceptions/Handler.php
@@ -1,22 +1,50 @@
 <?php namespace Orchestra\Testbench\Exceptions;
 
 use Exception;
+use Illuminate\Foundation\Testing\HttpException;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Validation\ValidationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 
 class Handler extends ExceptionHandler
 {
     /**
+     * A list of the exception types that should not be reported.
+     *
+     * @var array
+     */
+    protected $dontReport = [
+        AuthorizationException::class,
+        HttpException::class,
+        ModelNotFoundException::class,
+        ValidationException::class,
+    ];
+
+    /**
+     * Report or log an exception.
+     *
+     * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
+     *
+     * @param  \Exception  $e
+     * @return void
+     */
+    public function report(Exception $e)
+    {
+        return parent::report($e);
+    }
+
+    /**
      * Render an exception into an HTTP response.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $e
-     *
      * @return \Illuminate\Http\Response
-     *
-     * @throws \Exception
      */
     public function render($request, Exception $e)
     {
-        throw $e;
+        return parent::render($request, $e);
     }
 }
+


### PR DESCRIPTION
Hello,

Thank you for all the work you have done on this fantastic package - it is really magnificent and super helpful.  

I am in the process of upgrading one of my packages to be compatible with Laravel 5.2 and some of the integration tests look for validation errors to be triggered,  Those errors seem to be handled differently in 5.2 than they were in 5.1 and this PR is intended to update the TestBench exception handler to match the new 5.2 framework exception handler.   

Feel free to ignore this if you would prefer a different method - any advice you have would be appreciated. 

Thanks!