### PR TITLE
Put lifetime variable back in the session testcase

### DIFF
--- a/fixture/config/session.php
+++ b/fixture/config/session.php
@@ -29,7 +29,7 @@ return [
     |
     */
 
-    // 'lifetime' => 120,
+    'lifetime' => 120,
 
     // 'expire_on_close' => false,
 


### PR DESCRIPTION
A PR in Laravel added session lifetime into 5.2 and 5.3 for the CsrfToken middleware (https://github.com/laravel/framework/blob/5.2/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php#L137) https://github.com/laravel/framework/pull/14080/files
(This needs to be merged into the 3.3 branch as well.)