### PR TITLE
Add DatabaseMigrationsRealpath Trait

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -16,6 +16,7 @@ use Illuminate\Foundation\Testing\Concerns\InteractsWithDatabase;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithContainer;
 use Illuminate\Foundation\Testing\Concerns\MocksApplicationServices;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithAuthentication;
+use Orchestra\Testbench\Traits\DatabaseMigrationsRealpath;
 
 abstract class TestCase extends \PHPUnit_Framework_TestCase implements TestCaseContract
 {
@@ -114,6 +115,11 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase implements TestCaseC
             $this->runDatabaseMigrations();
         }
 
+        if (isset($uses[DatabaseMigrationsRealpath::class])) {
+            $realpath = $this->migrationsRealpath();
+            $this->runDatabaseMigrations($realpath);
+        }
+
         if (isset($uses[WithoutMiddleware::class])) {
             $this->disableMiddlewareForAllTests();
         }
@@ -121,6 +127,14 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase implements TestCaseC
         if (isset($uses[WithoutEvents::class])) {
             $this->disableEventsForAllTests();
         }
+    }
+
+    protected function migrationsRealpath()
+    {
+        throw new \Exception(
+            'To use realpath migrations, please override the migrationsRealpath() function.'
+        );
+        // return realpath(__DIR__.'/../database/migrations');
     }
 
     /**

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -116,8 +116,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase implements TestCaseC
         }
 
         if (isset($uses[DatabaseMigrationsRealpath::class])) {
-            $realpath = $this->migrationsRealpath();
-            $this->runDatabaseMigrations($realpath);
+            $this->runDatabaseMigrations($this->getMigrationsRealpath());
         }
 
         if (isset($uses[WithoutMiddleware::class])) {
@@ -129,10 +128,10 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase implements TestCaseC
         }
     }
 
-    protected function migrationsRealpath()
+    protected function getMigrationsRealpath()
     {
         throw new \Exception(
-            'To use realpath migrations, please override the migrationsRealpath() function.'
+            'To use realpath migrations, please override the getMigrationsRealpath() function.'
         );
         // return realpath(__DIR__.'/../database/migrations');
     }

--- a/src/Traits/DatabaseMigrationsRealpath.php
+++ b/src/Traits/DatabaseMigrationsRealpath.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Orchestra\Testbench\Traits;
+
+trait DatabaseMigrationsRealpath
+{
+    /**
+     * Define hooks to migrate the database before and after each test.
+     *
+     * @return void
+     */
+    public function runDatabaseMigrations($realpath)
+    {
+        $this->artisan('migrate', [
+            '--realpath' => $realpath,
+        ]);
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('migrate:rollback');
+        });
+    }
+}

--- a/tests/DatabaseTraitTest.php
+++ b/tests/DatabaseTraitTest.php
@@ -29,7 +29,7 @@ class DatabaseTraitTest extends \Orchestra\Testbench\TestCase
         */
     }
 
-    protected function migrationsRealpath()
+    protected function getMigrationsRealpath()
     {
         return realpath(__DIR__.'/migrations');
     }

--- a/tests/DatabaseTraitTest.php
+++ b/tests/DatabaseTraitTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Orchestra\Testbench\TestCase;
+
+use Orchestra\Testbench\Traits\DatabaseMigrationsRealpath;
+
+class DatabaseTraitTest extends \Orchestra\Testbench\TestCase
+{
+	use DatabaseMigrationsRealpath;
+	
+    /**
+     * Setup the test environment.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        // uncomment to enable route filters if your package defines routes with filters
+        // $this->app['router']->enableFilters();
+
+        // call migrations for packages upon which our package depends, e.g. Cartalyst/Sentry
+        // not necessary if your package doesn't depend on another package that requires
+        // running migrations for proper installation
+        /* uncomment as necessary
+        $this->artisan('migrate', [
+            '--database' => 'testbench',
+            '--path'     => '../vendor/cartalyst/sentry/src/migrations',
+        ]);
+        */
+    }
+
+    protected function migrationsRealpath()
+    {
+        return realpath(__DIR__.'/migrations');
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'testing');
+    }
+
+    /**
+     * Get package providers.  At a minimum this is the package being tested, but also
+     * would include packages upon which our package depends, e.g. Cartalyst/Sentry
+     * In a normal app environment these would be added to the 'providers' array in
+     * the config/app.php file.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            //'Cartalyst\Sentry\SentryServiceProvider',
+            //'YourProject\YourPackage\YourPackageServiceProvider',
+        ];
+    }
+
+    /**
+     * Get package aliases.  In a normal app environment these would be added to
+     * the 'aliases' array in the config/app.php file.  If your package exposes an
+     * aliased facade, you should add the alias here, along with aliases for
+     * facades upon which your package depends, e.g. Cartalyst/Sentry.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return array
+     */
+    protected function getPackageAliases($app)
+    {
+        return [
+            //'Sentry'      => 'Cartalyst\Sentry\Facades\Laravel\Sentry',
+            //'YourPackage' => 'YourProject\YourPackage\Facades\YourPackage',
+        ];
+    }
+
+    /**
+     * Test running migration.
+     *
+     * @test
+     */
+    public function testRunningMigration()
+    {
+        $users = \DB::table('users')->where('id', '=', 1)->first();
+
+        $this->assertEquals('hello@orchestraplatform.com', $users->email);
+        $this->assertTrue(\Hash::check('123', $users->password));
+        
+        $this->beforeApplicationDestroyed(function () {
+            $this->assertSame(\Schema::hasTable('users'), false);
+        });
+    }
+}


### PR DESCRIPTION
This closes #121.

As it turns out migrate:rollback does not need a realpath attribute so I did not do that.  Since the DatabaseMigrations trait was already pulled in from Laravel, I created a new trait call DatabaseMigartionsRealpath.  To use this trait the user must create a function like the one below

    protected function getMigrationsRealpath()
    {
        return realpath(__DIR__.'/migrations');
    }

Also, please merge this into 3.3.  I did not include this for 3.1 since that branch did not have any of the standard laravel traits enabled yet.  I can create a separate pull for 3.1 if that is desired.