### PR TITLE
Create a load migrations from function to do database migrations

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -74,6 +74,23 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase implements TestCaseI
     }
 
     /**
+     * Define hooks to migrate the database before and after each test.
+     *
+     * @param  string  $realpah
+     * @return void
+     */
+    public function loadMigrationsFrom($realpath)
+    {
+        $this->artisan('migrate', [
+            '--realpath' => $realpath,
+        ]);
+
+        $this->beforeApplicationDestroyed(function () {
+            $this->artisan('migrate:rollback');
+        });
+    }
+
+    /**
      * Register a callback to be run before the application is destroyed.
      *
      * @param  callable  $callback

--- a/tests/DatabaseLoadMigrationTest.php
+++ b/tests/DatabaseLoadMigrationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Orchestra\Testbench\TestCase;
+
+class DatabaseLoadMigrationsTest extends \Orchestra\Testbench\TestCase
+{
+	
+    /**
+     * Setup the test environment.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        // uncomment to enable route filters if your package defines routes with filters
+        // $this->app['router']->enableFilters();
+
+        // call migrations for packages upon which our package depends, e.g. Cartalyst/Sentry
+        // not necessary if your package doesn't depend on another package that requires
+        // running migrations for proper installation
+        /* uncomment as necessary
+        $this->artisan('migrate', [
+            '--database' => 'testbench',
+            '--path'     => '../vendor/cartalyst/sentry/src/migrations',
+        ]);
+        */
+        $this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'testing');
+    }
+
+    /**
+     * Get package providers.  At a minimum this is the package being tested, but also
+     * would include packages upon which our package depends, e.g. Cartalyst/Sentry
+     * In a normal app environment these would be added to the 'providers' array in
+     * the config/app.php file.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            //'Cartalyst\Sentry\SentryServiceProvider',
+            //'YourProject\YourPackage\YourPackageServiceProvider',
+        ];
+    }
+
+    /**
+     * Get package aliases.  In a normal app environment these would be added to
+     * the 'aliases' array in the config/app.php file.  If your package exposes an
+     * aliased facade, you should add the alias here, along with aliases for
+     * facades upon which your package depends, e.g. Cartalyst/Sentry.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return array
+     */
+    protected function getPackageAliases($app)
+    {
+        return [
+            //'Sentry'      => 'Cartalyst\Sentry\Facades\Laravel\Sentry',
+            //'YourPackage' => 'YourProject\YourPackage\Facades\YourPackage',
+        ];
+    }
+
+    /**
+     * Test running migration.
+     *
+     * @test
+     */
+    public function testRunningMigration()
+    {
+        $users = \DB::table('users')->where('id', '=', 1)->first();
+
+        $this->assertEquals('hello@orchestraplatform.com', $users->email);
+        $this->assertTrue(\Hash::check('123', $users->password));
+        
+        $this->beforeApplicationDestroyed(function () {
+            $this->assertSame(\Schema::hasTable('users'), false);
+        });
+    }
+}


### PR DESCRIPTION
Fix for #123 #121 

The one downside to this is that the override function can be done in TestCase.php in the project. Then any files the need migrations would be given the trait and would have migrations run. In this method, you'd need to override setup in each test class that needs migrations and either include the migrations path there or call a similar function in the parent testcase.

This method is cleaner for new adopters though and nice for 3.1/3.2/3.3 compatibility.