### PR TITLE
Fix missing null driver configuration

### DIFF
--- a/fixture/config/broadcasting.php
+++ b/fixture/config/broadcasting.php
@@ -49,6 +49,9 @@ return [
             'driver' => 'log',
         ],
 
+        'null' => [
+            'driver' => 'null',
+        ],
     ],
 
 ];


### PR DESCRIPTION
A null driver was missing from your default configuration, which causes the BroadcastManager to fail, when that driver is used.