### PR TITLE
Encrypt cookies

### DIFF
--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -27,6 +27,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
      */
     protected $middlewareGroups = [
         'web' => [
+            \Illuminate\Cookie\Middleware\EncryptCookies::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             Middleware\VerifyCsrfToken::class,


### PR DESCRIPTION
Since [the `seeCookie` method defaults to encrypted cookies](https://github.com/laravel/framework/commit/6526af679f136f029ad6e2f0b99bac5e72fa980c), I think it is nice if Testbench also encrypts cookies by default.