### PR TITLE
Use namespaced PHPUnit TestCase

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -4,6 +4,7 @@ namespace Orchestra\Testbench;
 
 use Mockery;
 use Orchestra\Testbench\Traits\WithFactories;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 use Illuminate\Foundation\Testing\WithoutEvents;
 use Orchestra\Testbench\Traits\ApplicationTrait;
 use Illuminate\Foundation\Testing\WithoutMiddleware;
@@ -18,7 +19,7 @@ use Illuminate\Foundation\Testing\Concerns\InteractsWithContainer;
 use Illuminate\Foundation\Testing\Concerns\MocksApplicationServices;
 use Illuminate\Foundation\Testing\Concerns\InteractsWithAuthentication;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase implements TestCaseContract
+abstract class TestCase extends BaseTestCase implements TestCaseContract
 {
     use ApplicationTrait,
         InteractsWithContainer,


### PR DESCRIPTION
Switched to the namespaced `PHPUnit\Framework\TestCase` class from `PHPUnit_Framework_TestCase` in preparation for PHPUnit 6.0 (already available in version 5). This will also make it possible to use PHPUnit 6.0 which will be released next week.

See this tweet by @sebastianbergmann: https://twitter.com/s_bergmann/status/814846275099181056