### PR TITLE
Fix authorize middleware

### DIFF
--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -55,7 +55,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
         'auth'       => \Illuminate\Auth\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings'   => \Illuminate\Routing\Middleware\SubstituteBindings::class,
-        'can'        => \Illuminate\Foundation\Http\Middleware\Authorize::class,
+        'can'        => \Illuminate\Auth\Middleware\Authorize::class,
         'guest'      => Middleware\RedirectIfAuthenticated::class,
         'throttle'   => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];


### PR DESCRIPTION
The [Authorize](https://github.com/laravel/framework/blob/5.4/src/Illuminate/Auth/Middleware/Authorize.php) middleware has been moved.