### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=5.6.0",
         "laravel/framework": "~5.4.17",
         "fzaninotto/faker": "~1.4",
-        "symfony/css-selector": "~3.2.0",
+        "symfony/css-selector": "~3.3.0",
         "symfony/dom-crawler": "~3.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
orchestra/testbench v3.4 requires symfony/css-selector ~3.2.0
Installation request for symfony/css-selector (locked at v3.3.0)
v5.4.24 of Laravel