### PR TITLE
Update branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0-dev"
+            "dev-master": "4.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
My build for Horizon with Symfony 5 support was failing because Composer believes atm that 5.0.x-dev targets the 4.x branch because of the current branch alias.

https://travis-ci.org/laravel/horizon/jobs/616761151

I've updated it to the correct branch alias as well by setting it to `4.x-dev` because that's the proper notation. Otherwise Composer believes this branch only holds patch releases. We did the same change for the framework and we're also rolling it out on the other first party libraries. 

testbench-core also needs to be updated with this as well as both master branches of the repos: https://github.com/orchestral/testbench-core/blob/4.x/composer.json#L47