### PR TITLE
Allow PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel/framework": "^6.4",
         "mockery/mockery": "^1.2.3",
         "orchestra/testbench-core": "^4.4.1",
-        "phpunit/phpunit": "^8.3"
+        "phpunit/phpunit": "^8.3|^9.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
https://github.com/laravel/framework/pull/30947 will add PHPUnit 9 support to Laravel 6+.