### PR TITLE
[6.x] list spatie/laravel-ray as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
         "laravel/framework": "^8.75",
         "mockery/mockery": "^1.4.4",
         "orchestra/testbench-core": "^6.28",
-        "phpunit/phpunit": "^8.5.21 || ^9.5.10",
+        "phpunit/phpunit": "^8.5.21 || ^9.5.10"
+    },
+    "require-dev": {
         "spatie/laravel-ray": "^1.26.2"
     },
     "extra": {


### PR DESCRIPTION
I think spatie/laravel-ray can be listed as a dev dependency 
(the same applies for the 7.x branch)