### PR TITLE
Update CHANGELOG-9.x.md version title

### DIFF
--- a/CHANGELOG-9.x.md
+++ b/CHANGELOG-9.x.md
@@ -1,4 +1,4 @@
-# Changes for 8.x
+# Changes for 9.x
 
 This changelog references the relevant changes (bug and security fixes) done to `orchestra/testbench`.
 


### PR DESCRIPTION
Noticed the changelog docs for v9 had the old label for 8.x.